### PR TITLE
fix(lightspeed): scope JSS class names to prevent style collisions

### DIFF
--- a/workspaces/lightspeed/.changeset/fix-lightspeed-jss-class-collision.md
+++ b/workspaces/lightspeed/.changeset/fix-lightspeed-jss-class-collision.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/backstage-plugin-lightspeed': patch
+---
+
+Scope all JSS class names with a `lightspeed-` prefix via seeded `StylesProvider` to prevent CSS collisions with other dynamically loaded plugins in RHDH.

--- a/workspaces/lightspeed/plugins/lightspeed/report.api.md
+++ b/workspaces/lightspeed/plugins/lightspeed/report.api.md
@@ -36,7 +36,7 @@ export const LightspeedDrawerStateExposer: (
 ) => null;
 
 // @public
-export const LightspeedFAB: () => JSX_2.Element | null;
+export const LightspeedFAB: () => JSX_2.Element;
 
 // @public
 export const LightspeedIcon: () => JSX_2.Element;

--- a/workspaces/lightspeed/plugins/lightspeed/src/alpha/LightspeedFAB.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/alpha/LightspeedFAB.tsx
@@ -56,11 +56,6 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-/**
- * @alpha
- * Lightspeed Floating action button to open/close the lightspeed chatbot
- */
-
 const LightspeedFABInner = () => {
   const { t } = useTranslation();
   const { isChatbotActive, toggleChatbot, displayMode } =
@@ -99,6 +94,10 @@ const LightspeedFABInner = () => {
   );
 };
 
+/**
+ * @alpha
+ * Lightspeed Floating action button to open/close the lightspeed chatbot
+ */
 export const LightspeedFAB = () => (
   <StylesProvider generateClassName={generateClassName}>
     <StylesProviderV4 generateClassName={generateClassNameV4}>

--- a/workspaces/lightspeed/plugins/lightspeed/src/alpha/LightspeedFAB.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/alpha/LightspeedFAB.tsx
@@ -14,16 +14,21 @@
  * limitations under the License.
  */
 
+import { StylesProvider as StylesProviderV4 } from '@material-ui/core/styles';
 import Close from '@mui/icons-material/Close';
 import Fab from '@mui/material/Fab';
 import Tooltip from '@mui/material/Tooltip';
-import { makeStyles } from '@mui/styles';
+import { makeStyles, StylesProvider } from '@mui/styles';
 import { ChatbotDisplayMode } from '@patternfly/chatbot';
 
 import { LightspeedFABIcon } from '../components/LightspeedIcon';
 import { DOCKED_CONTENT_OFFSET } from '../const';
 import { useLightspeedDrawerContext } from '../hooks/useLightspeedDrawerContext';
 import { useTranslation } from '../hooks/useTranslation';
+import {
+  generateClassName,
+  generateClassNameV4,
+} from '../utils/generateClassName';
 
 const useStyles = makeStyles(theme => ({
   fab: {
@@ -56,7 +61,7 @@ const useStyles = makeStyles(theme => ({
  * Lightspeed Floating action button to open/close the lightspeed chatbot
  */
 
-export const LightspeedFAB = () => {
+const LightspeedFABInner = () => {
   const { t } = useTranslation();
   const { isChatbotActive, toggleChatbot, displayMode } =
     useLightspeedDrawerContext();
@@ -93,3 +98,11 @@ export const LightspeedFAB = () => {
     </div>
   );
 };
+
+export const LightspeedFAB = () => (
+  <StylesProvider generateClassName={generateClassName}>
+    <StylesProviderV4 generateClassName={generateClassNameV4}>
+      <LightspeedFABInner />
+    </StylesProviderV4>
+  </StylesProvider>
+);

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatContainer.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedChatContainer.tsx
@@ -20,14 +20,22 @@ import { useAsync } from 'react-use';
 import { identityApiRef, useApi } from '@backstage/core-plugin-api';
 
 import { Button } from '@material-ui/core';
-import { useTheme } from '@material-ui/core/styles';
+import {
+  StylesProvider as StylesProviderV4,
+  useTheme,
+} from '@material-ui/core/styles';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import { StylesProvider } from '@mui/styles';
 import { QueryClientProvider } from '@tanstack/react-query';
 
 import { useAllModels } from '../hooks/useAllModels';
 import { useLightspeedViewPermission } from '../hooks/useLightspeedViewPermission';
 import { useTopicRestrictionStatus } from '../hooks/useQuestionValidation';
 import { useTranslation } from '../hooks/useTranslation';
+import {
+  generateClassName,
+  generateClassNameV4,
+} from '../utils/generateClassName';
 import queryClient from '../utils/queryClient';
 import FileAttachmentContextProvider from './AttachmentContext';
 import { LightspeedChat } from './LightSpeedChat';
@@ -213,8 +221,12 @@ const LightspeedChatContainerInner = () => {
  */
 export const LightspeedChatContainer = () => {
   return (
-    <QueryClientProvider client={queryClient}>
-      <LightspeedChatContainerInner />
-    </QueryClientProvider>
+    <StylesProvider generateClassName={generateClassName}>
+      <StylesProviderV4 generateClassName={generateClassNameV4}>
+        <QueryClientProvider client={queryClient}>
+          <LightspeedChatContainerInner />
+        </QueryClientProvider>
+      </StylesProviderV4>
+    </StylesProvider>
   );
 };

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedDrawerProvider.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedDrawerProvider.tsx
@@ -16,11 +16,16 @@
 
 import { PropsWithChildren } from 'react';
 
-import { makeStyles } from '@mui/styles';
+import { StylesProvider as StylesProviderV4 } from '@material-ui/core/styles';
+import { makeStyles, StylesProvider } from '@mui/styles';
 import { ChatbotModal } from '@patternfly/chatbot';
 
 import { DOCKED_CONTENT_OFFSET } from '../const';
 import { useLightspeedProviderState } from '../hooks/useLightspeedProviderState';
+import {
+  generateClassName,
+  generateClassNameV4,
+} from '../utils/generateClassName';
 import { LightspeedChatContainer } from './LightspeedChatContainer';
 import { LightspeedDrawerContext } from './LightspeedDrawerContext';
 
@@ -42,7 +47,7 @@ const useStyles = makeStyles(theme => ({
 /**
  * @public
  */
-export const LightspeedDrawerProvider = ({ children }: PropsWithChildren) => {
+const LightspeedDrawerProviderInner = ({ children }: PropsWithChildren) => {
   const classes = useStyles();
   const { contextValue, shouldRenderOverlayModal, closeChatbot } =
     useLightspeedProviderState();
@@ -66,3 +71,11 @@ export const LightspeedDrawerProvider = ({ children }: PropsWithChildren) => {
     </LightspeedDrawerContext.Provider>
   );
 };
+
+export const LightspeedDrawerProvider = ({ children }: PropsWithChildren) => (
+  <StylesProvider generateClassName={generateClassName}>
+    <StylesProviderV4 generateClassName={generateClassNameV4}>
+      <LightspeedDrawerProviderInner>{children}</LightspeedDrawerProviderInner>
+    </StylesProviderV4>
+  </StylesProvider>
+);

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedDrawerProvider.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedDrawerProvider.tsx
@@ -44,9 +44,6 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-/**
- * @public
- */
 const LightspeedDrawerProviderInner = ({ children }: PropsWithChildren) => {
   const classes = useStyles();
   const { contextValue, shouldRenderOverlayModal, closeChatbot } =
@@ -72,6 +69,9 @@ const LightspeedDrawerProviderInner = ({ children }: PropsWithChildren) => {
   );
 };
 
+/**
+ * @public
+ */
 export const LightspeedDrawerProvider = ({ children }: PropsWithChildren) => (
   <StylesProvider generateClassName={generateClassName}>
     <StylesProviderV4 generateClassName={generateClassNameV4}>

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedFAB.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedFAB.tsx
@@ -56,11 +56,6 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-/**
- * @public
- * Lightspeed Floating action button to open/close the lightspeed chatbot
- */
-
 const LightspeedFABInner = () => {
   const { t } = useTranslation();
   const { isChatbotActive, toggleChatbot, displayMode } =
@@ -99,6 +94,10 @@ const LightspeedFABInner = () => {
   );
 };
 
+/**
+ * @public
+ * Lightspeed Floating action button to open/close the lightspeed chatbot
+ */
 export const LightspeedFAB = () => (
   <StylesProvider generateClassName={generateClassName}>
     <StylesProviderV4 generateClassName={generateClassNameV4}>

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedFAB.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/LightspeedFAB.tsx
@@ -14,15 +14,20 @@
  * limitations under the License.
  */
 
+import { StylesProvider as StylesProviderV4 } from '@material-ui/core/styles';
 import Close from '@mui/icons-material/Close';
 import Fab from '@mui/material/Fab';
 import Tooltip from '@mui/material/Tooltip';
-import { makeStyles } from '@mui/styles';
+import { makeStyles, StylesProvider } from '@mui/styles';
 import { ChatbotDisplayMode } from '@patternfly/chatbot';
 
 import { DOCKED_CONTENT_OFFSET } from '../const';
 import { useLightspeedDrawerContext } from '../hooks/useLightspeedDrawerContext';
 import { useTranslation } from '../hooks/useTranslation';
+import {
+  generateClassName,
+  generateClassNameV4,
+} from '../utils/generateClassName';
 import { LightspeedFABIcon } from './LightspeedIcon';
 
 const useStyles = makeStyles(theme => ({
@@ -56,7 +61,7 @@ const useStyles = makeStyles(theme => ({
  * Lightspeed Floating action button to open/close the lightspeed chatbot
  */
 
-export const LightspeedFAB = () => {
+const LightspeedFABInner = () => {
   const { t } = useTranslation();
   const { isChatbotActive, toggleChatbot, displayMode } =
     useLightspeedDrawerContext();
@@ -93,3 +98,11 @@ export const LightspeedFAB = () => {
     </div>
   );
 };
+
+export const LightspeedFAB = () => (
+  <StylesProvider generateClassName={generateClassName}>
+    <StylesProviderV4 generateClassName={generateClassNameV4}>
+      <LightspeedFABInner />
+    </StylesProviderV4>
+  </StylesProvider>
+);

--- a/workspaces/lightspeed/plugins/lightspeed/src/components/Router.tsx
+++ b/workspaces/lightspeed/plugins/lightspeed/src/components/Router.tsx
@@ -18,6 +18,13 @@ import { Route, Routes } from 'react-router-dom';
 
 import { configApiRef, useApi } from '@backstage/core-plugin-api';
 
+import { StylesProvider as StylesProviderV4 } from '@material-ui/core/styles';
+import { StylesProvider } from '@mui/styles';
+
+import {
+  generateClassName,
+  generateClassNameV4,
+} from '../utils/generateClassName';
 import { LightspeedPage } from './LightspeedPage';
 
 /**
@@ -29,18 +36,25 @@ export const Router = () => {
     configApi.getOptionalBoolean('lightspeed.notebooks.enabled') ?? false;
 
   return (
-    <Routes>
-      <Route path="/" element={<LightspeedPage />} />
-      <Route
-        path="/conversation/:conversationId"
-        element={<LightspeedPage />}
-      />
-      {notebooksEnabled && (
-        <>
-          <Route path="/notebooks" element={<LightspeedPage />} />
-          <Route path="/notebooks/:notebookId" element={<LightspeedPage />} />
-        </>
-      )}
-    </Routes>
+    <StylesProvider generateClassName={generateClassName}>
+      <StylesProviderV4 generateClassName={generateClassNameV4}>
+        <Routes>
+          <Route path="/" element={<LightspeedPage />} />
+          <Route
+            path="/conversation/:conversationId"
+            element={<LightspeedPage />}
+          />
+          {notebooksEnabled && (
+            <>
+              <Route path="/notebooks" element={<LightspeedPage />} />
+              <Route
+                path="/notebooks/:notebookId"
+                element={<LightspeedPage />}
+              />
+            </>
+          )}
+        </Routes>
+      </StylesProviderV4>
+    </StylesProvider>
   );
 };

--- a/workspaces/lightspeed/plugins/lightspeed/src/utils/generateClassName.ts
+++ b/workspaces/lightspeed/plugins/lightspeed/src/utils/generateClassName.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createGenerateClassName as createGenerateClassNameV4 } from '@material-ui/core/styles';
+import { createGenerateClassName } from '@mui/styles';
+
+export const generateClassName = createGenerateClassName({
+  seed: 'lightspeed',
+});
+
+export const generateClassNameV4 = createGenerateClassNameV4({
+  seed: 'lightspeed',
+});


### PR DESCRIPTION
## Fix: CSS class name collision from lightspeed plugin
## UI after changes 

https://github.com/user-attachments/assets/f564a1a8-fdea-45c3-89aa-5f196170ce18


## Issue

Same root cause as #3090 (bulk-import), but on the lightspeed side.

#### Reason for the bug

- The lightspeed plugin uses `makeStyles` (JSS) from both `@mui/styles` and `@material-ui/core/styles`, which generate global class names such as `jss1`, `jss2`, etc.
- In RHDH, dynamically loaded plugins create independent JSS instances with counters starting from `1`, causing identical class names across plugins.
- Since styles are injected into the same document `<head>`, Lightspeed's `!important` styles (`position: fixed`, `backgroundColor`, `maxWidth`, `boxShadow`) leak into other plugins' DOM.

## Fix

- Created a shared seeded class name generator (`src/utils/generateClassName.ts`) with seed `'lightspeed'` for both `@mui/styles` (v5 JSS) and `@material-ui/core/styles` (v4 JSS).
- Wrapped **all** top-level plugin entry points with nested `StylesProvider` from both packages:
  - `Router.tsx` (page routes)
  - `LightspeedFAB.tsx` (floating action button)
  - `LightspeedDrawerProvider.tsx` (overlay drawer)
  - `LightspeedChatContainer.tsx` (standalone chat container)
  - `alpha/LightspeedFAB.tsx` (new frontend system FAB)

This prefixes all JSS class names with `lightspeed-` (e.g. `lightspeed-jss1`), preventing collisions with other plugins.

### Why all entry points?

Unlike bulk-import (which only has one `Router`), lightspeed exports 5 component extensions via `plugin.ts`. The FAB and drawer load **outside** the page route tree as independent `createComponentExtension` entries. Wrapping only `Router.tsx` would miss the very components whose styles caused the original leak.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/redhat-developer/rhdh-plugins/blob/main/CONTRIBUTING.md#creating-changesets))
- [ ] Added or Updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
